### PR TITLE
Add `offer-file` Command for CAR File Processing and Offer SubmissionFeat/offer file command

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -2,7 +2,13 @@ name: Go Test Workflow
 
 on:
   push:
+    branches:
+      - main
+      - dev
   pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
   test:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -2,13 +2,7 @@ name: Go Test Workflow
 
 on:
   push:
-    branches:
-      - main
-      - dev
   pull_request:
-    branches:
-      - main
-      - dev
 
 jobs:
   test:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,34 @@
+name: Go Test Workflow
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  test:
+    name: Run Go Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21  # Update to match your Go version
+
+      - name: Install Dependencies
+        run: |
+          go mod tidy
+          go mod download
+
+      - name: Run Go Tests (Verbose)
+        run: go test -v ./...
+

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ go.work.sum
 
 
 # config
-./config/xchain_key.json
+config/xchain_key.json

--- a/README.md
+++ b/README.md
@@ -111,42 +111,61 @@ Ensure the keystore file is correctly generated using `generate-account` and tha
 Check that your `Api` field in `config.json` is correctly set to a working Ethereum/Web3 provider.
 
 ---
-
 ## 🛠️ Configuration
 
 ### **Config File (`config.json`)**
 
-The Xchain Client now **uses a `config.json` file** for storing settings instead of a `.env` file. The configuration file should be placed inside the `config/` directory.
+The Xchain Client uses a `config.json` file to store its settings. The configuration file should be placed inside the `config/` directory.
 
 #### **Example `config.json`**
 ```json
-[
-  {
+{
+  "destination": {
     "ChainID": 314159,
-    "Api": "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1",
-    "OnRampAddress": "0x750CbAcFbE58C453cEA1E5a2617193D60B7Cb451",
-    "ProverAddr": "0x61F0ACE5ad40466Eb43141fa56Cf87758b6ffbA8",
-    "KeyPath": "./config/xchain_key.json",
-    "ClientAddr": "0x5c31e78f3f7329769734f5ff1ac7e22c243e817e",
-    "PayoutAddr": "0x5c31e78f3f7329769734f5ff1ac7e22c243e817e",
-    "OnRampABIPath": "./config/onramp-abi.json",
-    "BufferPath": "~/.xchain/buffer",
-    "BufferPort": 5077,
-    "ProviderAddr": "t0116147",
     "LotusAPI": "https://api.calibration.node.glif.io",
-    "LighthouseApiKey": "",
-    "LighthouseAuth": "u8t8gf6ds06re"
-  }
-]
+    "ProverAddr": "0x61F0ACE5ad40466Eb43141fa56Cf87758b6ffbA8"
+  },
+  "sources": {
+    "filecoin": {
+      "Api": "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1",
+      "OnRampAddress": "0x750CbAcFbE58C453cEA1E5a2617193D60B7Cb451"
+    },
+    "avalanche": {
+      "Api": "wss://api.avax-test.network/ext/bc/C/ws",
+      "OnRampAddress": "0x123...abc"
+    },
+    "polygon": {
+      "Api": "wss://polygon-rpc.com",
+      "OnRampAddress": "0x456...def"
+    }
+  },
+  "KeyPath": "./config/xchain_key.json",
+  "ClientAddr": "0x5c31e78f3f7329769734f5ff1ac7e22c243e817e",
+  "PayoutAddr": "0x5c31e78f3f7329769734f5ff1ac7e22c243e817e",
+  "OnRampABIPath": "./config/onramp-abi.json",
+  "BufferPath": "~/.xchain/buffer",
+  "BufferPort": 5077,
+  "ProviderAddr": "t0116147",
+  "LighthouseApiKey": "",
+  "LighthouseAuth": "u8t8gf6ds06re",
+  "TransferIP": "0.0.0.0",
+  "TransferPort": 9999,
+  "TargetAggSize": 0
+}
 ```
 
 ### **Configuration Fields Explained**
 | Key | Description |
 |------|------------|
-| **ChainID** | Ethereum-compatible chain ID (e.g., `314159` for Filecoin Calibration Testnet). |
-| **Api** | WebSocket API URL for Ethereum client (e.g., Infura, Glif). |
-| **OnRampAddress** | Address of the OnRamp smart contract. |
-| **ProverAddr** | Ethereum address of the prover for verifying storage deals. |
+| **destination.ChainID** | Ethereum-compatible chain ID for the destination network. |
+| **destination.LotusAPI** | Filecoin Lotus API endpoint used for deal tracking. |
+| **destination.ProverAddr** | Ethereum address of the prover verifying storage deals. |
+| **sources.filecoin.Api** | WebSocket API for Filecoin calibration network. |
+| **sources.filecoin.OnRampAddress** | Filecoin OnRamp contract address. |
+| **sources.avalanche.Api** | WebSocket API for Avalanche network. |
+| **sources.avalanche.OnRampAddress** | Avalanche OnRamp contract address. |
+| **sources.polygon.Api** | WebSocket API for Polygon network. |
+| **sources.polygon.OnRampAddress** | Polygon OnRamp contract address. |
 | **KeyPath** | Path to the keystore file that contains the Ethereum private key. |
 | **ClientAddr** | Ethereum wallet address used for making transactions. |
 | **PayoutAddr** | Address where storage rewards should be sent. |
@@ -154,9 +173,19 @@ The Xchain Client now **uses a `config.json` file** for storing settings instead
 | **BufferPath** | Directory where temporary storage is kept before aggregation. |
 | **BufferPort** | Port for the buffer service (`5077` by default). |
 | **ProviderAddr** | Filecoin storage provider ID. |
-| **LotusAPI** | Filecoin Lotus API endpoint (used for deal tracking). |
 | **LighthouseApiKey** | API key for interacting with Lighthouse storage (if applicable). |
 | **LighthouseAuth** | Authentication token for Lighthouse. |
+| **TransferIP** | IP address for cross-chain data transfer service (`0.0.0.0` for all interfaces). |
+| **TransferPort** | Port for the cross-chain data transfer service (`9999` by default). |
+| **TargetAggSize** | Specifies the aggregation size for deal bundling (currently set to `0`). |
+
+### **Multi-Chain Support**
+Xchain Client supports interaction with multiple blockchains. Users can configure multiple `sources` to enable cross-chain deal submissions. Supported networks include:
+- **Filecoin**
+- **Avalanche**
+- **Polygon**
+
+Each source requires an **API endpoint** and an **OnRamp contract address**, which are specified under the `sources` field in `config.json`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,39 @@ To start the Xchain adapter daemon, run:
 
 ---
 
-## 📡 **Submitting an Offer**
+## 📡 **offering data with automatic car processing**
 
-To submit an offer to the OnRamp contract:
+the `offer-file` command simplifies offering data by automatically:
+
+1. converting the file into a car format.
+2. calculating the commp (content identifier for proofs).
+3. uploading the car file to a local buffer service.
+4. submitting an offer transaction to the blockchain.
 
 ```sh
-./xchainClient client offer <commP> <size> <cid> <bufferLocation> <token-hex> <token-amount>
+./xchainclient client offer-file <file_path> <payment-addr> <payment-amount> --chain ethereum --config ./config/config.json
 ```
 
-Example:
+example:
+
 ```sh
-./xchainClient client offer bafkreihdwdcef4n... 128 /data/file1 /buffers/ 0x6B175474E89094C44Da98b954EedeAC495271d0F 1000
+./xchainclient client offer-file ./data/sample.txt 0x5c31e78f3f7329769734f5ff1ac7e22c243e817e 1000 --chain polygon
+```
+
+---
+
+## 📡 **submitting an offer (manual method)**
+
+to submit an offer to the onramp contract manually:
+
+```sh
+./xchainclient client offer <commp> <size> <cid> <bufferlocation> <token-hex> <token-amount>
+```
+
+example:
+
+```sh
+./xchainclient client offer bafkreihdwdcef4n... 128 /data/file1 /buffers/ 0x6b175474e89094c44da98b954eedeac495271d0f 1000
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Keystore File Path: /home/user/onramp-contracts/xchain_key.json
 To start the Xchain adapter daemon, run:
 
 ```sh
-./xchainClient daemon --config ./config/config.json --buffer-service --aggregation-service
+./xchainClient --config ./config/config.json daemon --buffer-service --aggregation-service
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Xchain Client provides a set of tools to facilitate cross-chain data movement fr
 
 ## 🚀 Installation
 
-Ensure you have **Go 1.18+** installed. Then, clone the repository and build the project:
+Ensure you have **Go** installed. Then, clone the repository and build the project:
 
 ```sh
 git clone https://github.com/your-repo/xchainClient.git

--- a/client.go
+++ b/client.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/FIL-Builders/xchainClient/config"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-libipfs/blocks"
+	"github.com/ipfs/go-unixfsnode/data/builder"
+	"github.com/ipld/go-car/v2"
+	"github.com/ipld/go-car/v2/blockstore"
+	dagpb "github.com/ipld/go-codec-dagpb"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+	"github.com/urfave/cli/v2"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+	commp "github.com/filecoin-project/go-fil-commp-hashhash"
+)
+
+func offerFileAction(cctx *cli.Context) error {
+	// Expect exactly 3 arguments: <file_path> <payment-addr> <payment-amount>
+	if cctx.Args().Len() != 3 {
+		return fmt.Errorf("Usage: <file_path> <payment-addr> <payment-amount>")
+	}
+	filePath := cctx.Args().Get(0)
+	paymentAddr := cctx.Args().Get(1)
+	paymentAmount := cctx.Args().Get(2)
+
+	// Create the CAR file name.
+	carFilePath := filePath + ".car"
+	// Remove any existing CAR file.
+	if _, err := os.Stat(carFilePath); err == nil {
+		if err := os.Remove(carFilePath); err != nil {
+			return fmt.Errorf("failed to remove existing CAR file: %v", err)
+		}
+	}
+
+	// Create the CAR file (using our stub; replace with proper go-car logic as needed).
+	if err := createCarFile(filePath, carFilePath); err != nil {
+		return fmt.Errorf("failed to create CAR file: %v", err)
+	}
+
+	// Compute the CommP and padded piece size.
+	commPStr, paddedSize, err := calcStreamCommp(carFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to compute CommP: %v", err)
+	}
+	sizeStr := strconv.FormatUint(paddedSize, 10)
+
+	// Data Plane: Upload the CAR file to the local server.
+	carFileBytes, err := os.ReadFile(carFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read CAR file: %v", err)
+	}
+	urlPut := "http://localhost:5077/put"
+	resp, err := http.Post(urlPut, "application/octet-stream", bytes.NewReader(carFileBytes))
+	if err != nil {
+		return fmt.Errorf("failed to POST CAR file: %v", err)
+	}
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %v", err)
+	}
+	var postResult map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &postResult); err != nil {
+		return fmt.Errorf("failed to parse JSON response: %v", err)
+	}
+	var bufferID string
+	if idStr, ok := postResult["id"].(string); ok {
+		bufferID = idStr
+	} else if idNum, ok := postResult["id"].(float64); ok {
+		bufferID = strconv.FormatFloat(idNum, 'f', -1, 64)
+	} else {
+		return fmt.Errorf("failed to extract buffer id from response")
+	}
+	bufferAddr := fmt.Sprintf("http://localhost:5077/get?id=%s", bufferID)
+
+	// Blockchain: Load configuration and prepare the transaction.
+	cfg, err := config.LoadConfig(cctx.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to load config: %v", err)
+	}
+	chainName := cctx.String("chain")
+	srcCfg, err := config.GetSourceConfig(cfg, chainName)
+	if err != nil {
+		return fmt.Errorf("invalid chain name '%s': %v", chainName, err)
+	}
+	client, err := ethclient.Dial(srcCfg.Api)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Ethereum client for source chain %s at %s: %v", chainName, srcCfg.Api, err)
+	}
+	contractAddress := common.HexToAddress(srcCfg.OnRampAddress)
+	parsedABI, err := LoadAbi(cfg.OnRampABIPath)
+	if err != nil {
+		return fmt.Errorf("failed to load ABI: %v", err)
+	}
+	onramp := bind.NewBoundContract(contractAddress, *parsedABI, client, client, client)
+	auth, err := loadPrivateKey(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to load private key: %v", err)
+	}
+
+	// Map parameters for the offer.
+	// Here we use the computed commPStr both as the CommP and (as a placeholder) as the file CID.
+	offerObj, err := MakeOffer(commPStr, sizeStr, commPStr, bufferAddr, paymentAddr, paymentAmount, *parsedABI)
+	if err != nil {
+		return fmt.Errorf("failed to pack offer data params: %v", err)
+	}
+
+	// Submit the offer transaction.
+	tx, err := onramp.Transact(auth, "offerData", offerObj)
+	if err != nil {
+		return fmt.Errorf("failed to send transaction: %v", err)
+	}
+	log.Printf("Waiting for transaction: %s\n", tx.Hash().Hex())
+	receipt, err := bind.WaitMined(cctx.Context, client, tx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for tx: %v", err)
+	}
+	log.Printf("Tx %s included: %d", tx.Hash().Hex(), receipt.Status)
+	return nil
+}
+
+func createCarFile(inputPath, outputPath string) error {
+	ctx := context.Background()
+
+	// Create a placeholder CID for initialization
+	hasher, err := multihash.GetHasher(multihash.SHA2_256)
+	if err != nil {
+		return err
+	}
+	digest := hasher.Sum([]byte{})
+	hash, err := multihash.Encode(digest, multihash.SHA2_256)
+	if err != nil {
+		return err
+	}
+	proxyRoot := cid.NewCidV1(uint64(multicodec.DagPb), hash)
+
+	// Open CAR file for writing
+	options := []car.Option{blockstore.WriteAsCarV1(true)}
+
+	// Open CAR file for writing
+	bs, err := blockstore.OpenReadWrite(outputPath, []cid.Cid{proxyRoot}, options...)
+
+	if err != nil {
+		return err
+	}
+	defer bs.Finalize()
+
+	// Write UnixFS DAG
+	rootCID, err := writeFileToCar(ctx, bs, inputPath)
+	if err != nil {
+		return err
+	}
+	fmt.Println("CID ", rootCID)
+
+	// Replace root with actual rootCID
+	return car.ReplaceRootsInFile(outputPath, []cid.Cid{rootCID})
+}
+
+func writeFileToCar(ctx context.Context, bs *blockstore.ReadWrite, filePath string) (cid.Cid, error) {
+	ls := cidlink.DefaultLinkSystem()
+	ls.TrustedStorage = true
+
+	ls.StorageReadOpener = func(_ ipld.LinkContext, l ipld.Link) (io.Reader, error) {
+		cl, ok := l.(cidlink.Link)
+		if !ok {
+			return nil, fmt.Errorf("not a cidlink")
+		}
+		blk, err := bs.Get(ctx, cl.Cid)
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewBuffer(blk.RawData()), nil
+	}
+
+	ls.StorageWriteOpener = func(_ ipld.LinkContext) (io.Writer, ipld.BlockWriteCommitter, error) {
+		buf := bytes.NewBuffer(nil)
+		return buf, func(l ipld.Link) error {
+			cl, ok := l.(cidlink.Link)
+			if !ok {
+				return fmt.Errorf("not a cidlink")
+			}
+			blk, err := blocks.NewBlockWithCid(buf.Bytes(), cl.Cid)
+			if err != nil {
+				return err
+			}
+			return bs.Put(ctx, blk)
+		}, nil
+	}
+
+	// Open file and get its actual size
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return cid.Undef, err
+	}
+	fileSize := fi.Size()
+
+	// Build UnixFS DAG for input file
+	l, _, err := builder.BuildUnixFSRecursive(filePath, &ls)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	// Ensure size is set correctly
+	entry, err := builder.BuildUnixFSDirectoryEntry(path.Base(filePath), fileSize, l)
+
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	root, _, err := builder.BuildUnixFSDirectory([]dagpb.PBLink{entry}, &ls)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	rcl, ok := root.(cidlink.Link)
+	if !ok {
+		return cid.Undef, fmt.Errorf("could not interpret root as CID link")
+	}
+
+	fmt.Printf("Generated CAR Root CID: %s with File Size: %d\n", rcl.Cid.String(), fileSize)
+
+	return rcl.Cid, nil
+}
+
+const BufSize = ((16 << 20) / 128 * 127)
+
+// calcStreamCommp computes the CommP and padded piece size for a given CAR file.
+func calcStreamCommp(carPath string) (string, uint64, error) {
+	f, err := os.Open(carPath)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+
+	// Create a new CommP calculator
+	cp := new(commp.Calc)
+
+	// Buffered reader to optimize IO performance
+	streamBuf := bufio.NewReaderSize(f, BufSize)
+
+	// Feed data into commp.Calc via io.TeeReader
+	_, err = io.Copy(cp, streamBuf)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Compute raw CommP and padded size
+	rawCommP, paddedSize, err := cp.Digest()
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Convert raw CommP to CID
+	commCid, err := commcid.DataCommitmentV1ToCID(rawCommP)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return commCid.String(), paddedSize, nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// DestinationChainConfig represents the Filecoin destination.
+type DestinationChainConfig struct {
+	ChainID    int    `json:"ChainID"`
+	LotusAPI   string `json:"LotusAPI"`
+	ProverAddr string `json:"ProverAddr"`
+}
+
+// SourceChainConfig represents a blockchain that can send data to Filecoin.
+type SourceChainConfig struct {
+	Api           string `json:"Api"`
+	OnRampAddress string `json:"OnRampAddress"`
+}
+
+// Config holds all configuration parameters.
+type Config struct {
+	Destination      DestinationChainConfig       `json:"destination"`
+	Sources          map[string]SourceChainConfig `json:"sources"`
+	KeyPath          string                       `json:"KeyPath"`
+	ClientAddr       string                       `json:"ClientAddr"`
+	PayoutAddr       string                       `json:"PayoutAddr"`
+	OnRampABIPath    string                       `json:"OnRampABIPath"`
+	BufferPath       string                       `json:"BufferPath"`
+	BufferPort       int                          `json:"BufferPort"`
+	ProviderAddr     string                       `json:"ProviderAddr"`
+	LighthouseApiKey string                       `json:"LighthouseApiKey"`
+	LighthouseAuth   string                       `json:"LighthouseAuth"`
+	TransferIP       string                       `json:"TransferIP"`
+	TransferPort     int                          `json:"TransferPort"`
+	TargetAggSize    int                          `json:"TargetAggSize"`
+}
+
+// LoadConfig reads the configuration from a JSON file.
+func LoadConfig(path string) (*Config, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config file: %w", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(bytes, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to decode config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// GetSourceConfig retrieves a source chain's configuration by its name.
+func GetSourceConfig(cfg *Config, network string) (*SourceChainConfig, error) {
+	if srcCfg, exists := cfg.Sources[network]; exists {
+		return &srcCfg, nil
+	}
+	return nil, fmt.Errorf("source chain configuration for '%s' not found", network)
+}

--- a/config/config.json
+++ b/config/config.json
@@ -11,7 +11,7 @@
     },
     "avalanche": {
       "Api": "wss://api.avax-test.network/ext/bc/C/ws",
-      "OnRampAddress": "0x123...abc"
+      "OnRampAddress": "0x29E81A673915d5f099289e0cba31c49072710d01"
     },
     "polygon": {
       "Api": "wss://polygon-rpc.com",

--- a/config/config.json
+++ b/config/config.json
@@ -1,18 +1,33 @@
-[
-    {
-      "ChainID": 314159,
+{
+  "destination": {
+    "ChainID": 314159,
+    "LotusAPI": "https://api.calibration.node.glif.io",
+    "ProverAddr": "0x61F0ACE5ad40466Eb43141fa56Cf87758b6ffbA8"
+  },
+  "sources": {
+    "filecoin": {
       "Api": "wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1",
-      "OnRampAddress": "0x750CbAcFbE58C453cEA1E5a2617193D60B7Cb451",
-      "ProverAddr": "0x61F0ACE5ad40466Eb43141fa56Cf87758b6ffbA8",
-      "KeyPath": "./config/xchain_key.json",
-      "ClientAddr": "0x5c31e78f3f7329769734f5ff1ac7e22c243e817e",
-      "PayoutAddr": "0x5c31e78f3f7329769734f5ff1ac7e22c243e817e",
-      "OnRampABIPath": "./config/onramp-abi.json",
-      "BufferPath": "~/.xchain/buffer",
-      "BufferPort": 5077,
-      "ProviderAddr": "t0116147",
-      "LotusAPI": "https://api.calibration.node.glif.io",
-      "LighthouseApiKey": "",
-      "LighthouseAuth": "u8t8gf6ds06re"
+      "OnRampAddress": "0x750CbAcFbE58C453cEA1E5a2617193D60B7Cb451"
+    },
+    "avalanche": {
+      "Api": "wss://api.avax-test.network/ext/bc/C/ws",
+      "OnRampAddress": "0x123...abc"
+    },
+    "polygon": {
+      "Api": "wss://polygon-rpc.com",
+      "OnRampAddress": "0x456...def"
     }
-  ]
+  },
+  "KeyPath": "./config/xchain_key.json",
+  "ClientAddr": "0x5c31e78f3f7329769734f5ff1ac7e22c243e817e",
+  "PayoutAddr": "0x5c31e78f3f7329769734f5ff1ac7e22c243e817e",
+  "OnRampABIPath": "./config/onramp-abi.json",
+  "BufferPath": "~/.xchain/buffer",
+  "BufferPort": 5077,
+  "ProviderAddr": "t0116147",
+  "LighthouseApiKey": "",
+  "LighthouseAuth": "u8t8gf6ds06re",
+  "TransferIP": "0.0.0.0",
+  "TransferPort": 9999,
+  "TargetAggSize": 0
+}

--- a/go.mod
+++ b/go.mod
@@ -8,14 +8,23 @@ require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-cbor-util v0.0.1
 	github.com/filecoin-project/go-data-segment v0.0.1
+	github.com/filecoin-project/go-fil-commcid v0.1.0
+	github.com/filecoin-project/go-fil-commp-hashhash v0.2.0
 	github.com/filecoin-project/go-jsonrpc v0.5.0
 	github.com/filecoin-project/go-state-types v0.13.3
 	github.com/filecoin-project/lotus v1.27.0
 	github.com/google/uuid v1.6.0
 	github.com/ipfs/go-cid v0.4.1
+	github.com/ipfs/go-libipfs v0.7.0
+	github.com/ipfs/go-unixfsnode v1.9.0
+	github.com/ipld/go-car/v2 v2.13.1
+	github.com/ipld/go-codec-dagpb v1.6.0
+	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/libp2p/go-libp2p v0.35.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.12.4
+	github.com/multiformats/go-multicodec v0.9.0
+	github.com/multiformats/go-multihash v0.2.3
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.2
 	golang.org/x/sync v0.7.0
@@ -59,7 +68,6 @@ require (
 	github.com/filecoin-project/go-crypto v0.0.2-0.20240424000926-1808e310bbac // indirect
 	github.com/filecoin-project/go-data-transfer v1.15.4-boost // indirect
 	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc8 // indirect
-	github.com/filecoin-project/go-fil-commcid v0.1.0 // indirect
 	github.com/filecoin-project/go-fil-markets v1.28.3 // indirect
 	github.com/filecoin-project/go-hamt-ipld v0.1.5 // indirect
 	github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 // indirect
@@ -101,11 +109,13 @@ require (
 	github.com/invopop/jsonschema v0.12.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/boxo v0.20.0 // indirect
+	github.com/ipfs/go-bitfield v1.1.0 // indirect
 	github.com/ipfs/go-block-format v0.2.0 // indirect
 	github.com/ipfs/go-blockservice v0.5.2 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect
 	github.com/ipfs/go-graphsync v0.17.0 // indirect
 	github.com/ipfs/go-ipfs-blockstore v1.3.1 // indirect
+	github.com/ipfs/go-ipfs-chunker v0.0.5 // indirect
 	github.com/ipfs/go-ipfs-ds-help v1.1.1 // indirect
 	github.com/ipfs/go-ipfs-exchange-interface v0.2.1 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.3 // indirect
@@ -118,8 +128,6 @@ require (
 	github.com/ipfs/go-metrics-interface v0.0.1 // indirect
 	github.com/ipfs/go-verifcid v0.0.3 // indirect
 	github.com/ipld/go-car v0.6.2 // indirect
-	github.com/ipld/go-codec-dagpb v1.6.0 // indirect
-	github.com/ipld/go-ipld-prime v0.21.0 // indirect
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1 // indirect
 	github.com/ipni/go-libipni v0.0.8 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
@@ -155,8 +163,6 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
-	github.com/multiformats/go-multicodec v0.9.0 // indirect
-	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/nkovacs/streamquote v1.0.0 // indirect
@@ -164,6 +170,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
+	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 // indirect
 	github.com/pion/datachannel v1.5.6 // indirect
 	github.com/pion/dtls/v2 v2.2.11 // indirect
 	github.com/pion/ice/v2 v2.3.25 // indirect
@@ -201,7 +208,9 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.0.1 // indirect
 	github.com/whyrusleeping/bencher v0.0.0-20190829221104-bb6607aa8bba // indirect
+	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
 	github.com/whyrusleeping/cbor-gen v0.1.1 // indirect
+	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	gitlab.com/yawning/secp256k1-voi v0.0.0-20230925100816-f2616030848b // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.3
 	github.com/filecoin-project/boost v1.7.5
 	github.com/filecoin-project/go-address v1.1.0
+	github.com/filecoin-project/go-cbor-util v0.0.1
 	github.com/filecoin-project/go-data-segment v0.0.1
 	github.com/filecoin-project/go-jsonrpc v0.5.0
 	github.com/filecoin-project/go-state-types v0.13.3
@@ -15,6 +16,7 @@ require (
 	github.com/libp2p/go-libp2p v0.35.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.12.4
+	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.2
 	golang.org/x/sync v0.7.0
 
@@ -54,7 +56,6 @@ require (
 	github.com/filecoin-project/go-amt-ipld/v3 v3.1.0 // indirect
 	github.com/filecoin-project/go-amt-ipld/v4 v4.3.0 // indirect
 	github.com/filecoin-project/go-bitfield v0.2.4 // indirect
-	github.com/filecoin-project/go-cbor-util v0.0.1 // indirect
 	github.com/filecoin-project/go-crypto v0.0.2-0.20240424000926-1808e310bbac // indirect
 	github.com/filecoin-project/go-data-transfer v1.15.4-boost // indirect
 	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc8 // indirect
@@ -194,7 +195,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,8 @@ github.com/ipld/go-ipld-prime v0.10.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/
 github.com/ipld/go-ipld-prime v0.21.0 h1:n4JmcpOlPDIxBcY037SVfpd1G+Sj1nKZah0m6QH9C2E=
 github.com/ipld/go-ipld-prime v0.21.0/go.mod h1:3RLqy//ERg/y5oShXXdx5YIp50cFGOanyMctpPjsvxQ=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
+github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
+github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:wZ8hH8UxeryOs4kJEJaiui/s00hDSbE37OKsL47g+Sw=
 github.com/ipld/go-ipld-selector-text-lite v0.0.1 h1:lNqFsQpBHc3p5xHob2KvEg/iM5dIFn6iw4L/Hh+kS1Y=
 github.com/ipld/go-ipld-selector-text-lite v0.0.1/go.mod h1:U2CQmFb+uWzfIEF3I1arrDa5rwtj00PrpiwwCO+k1RM=
 github.com/ipni/go-libipni v0.0.8 h1:0wLfZRSBG84swmZwmaLKul/iB/FlBkkl9ZcR1ub+Z+w=

--- a/xchain.go
+++ b/xchain.go
@@ -193,7 +193,7 @@ func main() {
 							// Dial network
 							client, err := ethclient.Dial(srcCfg.Api)
 							if err != nil {
-								log.Fatal(err)
+								log.Fatalf("failed to connect to Ethereum client for source chain %s at %s: %v", chainName, srcCfg.Api, err)
 							}
 
 							// Load onramp contract handle
@@ -302,7 +302,7 @@ func main() {
 							// Dial network
 							client, err := ethclient.Dial(srcCfg.Api)
 							if err != nil {
-								log.Fatal(err)
+								log.Fatalf("failed to connect to Ethereum client for source chain %s at %s: %v", chainName, srcCfg.Api, err)
 							}
 
 							// Load onramp contract handle
@@ -484,7 +484,7 @@ func NewLotusDaemonAPIClientV0(ctx context.Context, url string, timeoutSecs int,
 func NewAggregator(ctx context.Context, cfg *config.Config, srcCfg *config.SourceChainConfig) (*aggregator, error) {
 	client, err := ethclient.Dial(srcCfg.Api)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("failed to connect to Ethereum client for source chain at %s: %w", srcCfg.Api, err)
 	}
 
 	parsedABI, err := LoadAbi(cfg.OnRampABIPath)
@@ -508,7 +508,7 @@ func NewAggregator(ctx context.Context, cfg *config.Config, srcCfg *config.Sourc
 
 	lAPI, closer, err := NewLotusDaemonAPIClientV0(ctx, cfg.Destination.LotusAPI, 1, "")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to the Ethereum client on the destination chain: using url %s: %v", cfg.Destination.LotusAPI, err)
 	}
 
 	// Get maddr for dialing boost from on chain miner actor

--- a/xchain.go
+++ b/xchain.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/FIL-Builders/xchainClient/config"
+
 	"bytes"
 	"context"
 	"encoding/hex"
@@ -70,6 +72,11 @@ func main() {
 						Usage: "Path to the configuration file",
 						Value: "./config/config.json",
 					},
+					&cli.StringFlag{
+						Name:     "chain",
+						Usage:    "Name of the source blockchain (e.g., ethereum, polygon)",
+						Required: true,
+					},
 					&cli.BoolFlag{
 						Name:  "buffer-service",
 						Usage: "Run a buffer server",
@@ -88,9 +95,16 @@ func main() {
 						isAgg = true
 					}
 
-					cfg, err := LoadConfig(cctx.String("config"))
+					cfg, err := config.LoadConfig(cctx.String("config"))
 					if err != nil {
 						log.Fatal(err)
+					}
+
+					// Get source chain name
+					chainName := cctx.String("chain")
+					srcCfg, err := config.GetSourceConfig(cfg, chainName)
+					if err != nil {
+						log.Fatalf("Invalid chain name '%s': %v", chainName, err)
 					}
 
 					g, ctx := errgroup.WithContext(cctx.Context)
@@ -134,7 +148,7 @@ func main() {
 						if !isAgg {
 							return nil
 						}
-						a, err := NewAggregator(ctx, cfg)
+						a, err := NewAggregator(ctx, cfg, srcCfg)
 						if err != nil {
 							return err
 						}
@@ -157,21 +171,33 @@ func main() {
 								Usage: "Path to the configuration file",
 								Value: "./config/config.json",
 							},
+							&cli.StringFlag{
+								Name:     "chain",
+								Usage:    "Name of the source blockchain (e.g., ethereum, polygon)",
+								Required: true,
+							},
 						},
 						Action: func(cctx *cli.Context) error {
-							cfg, err := LoadConfig(cctx.String("config"))
+							cfg, err := config.LoadConfig(cctx.String("config"))
 							if err != nil {
 								log.Fatal(err)
 							}
 
+							// Get chain name
+							chainName := cctx.String("chain")
+							srcCfg, err := config.GetSourceConfig(cfg, chainName)
+							if err != nil {
+								log.Fatalf("Invalid chain name '%s': %v", chainName, err)
+							}
+
 							// Dial network
-							client, err := ethclient.Dial(cfg.Api)
+							client, err := ethclient.Dial(srcCfg.Api)
 							if err != nil {
 								log.Fatal(err)
 							}
 
 							// Load onramp contract handle
-							contractAddress := common.HexToAddress(cfg.OnRampAddress)
+							contractAddress := common.HexToAddress(srcCfg.OnRampAddress)
 							parsedABI, err := LoadAbi(cfg.OnRampABIPath)
 							if err != nil {
 								log.Fatal(err)
@@ -227,9 +253,14 @@ func main() {
 								Usage: "Path to the configuration file",
 								Value: "./config/config.json",
 							},
+							&cli.StringFlag{
+								Name:     "chain",
+								Usage:    "Name of the source blockchain (e.g., ethereum, polygon)",
+								Required: true,
+							},
 						},
 						Action: func(cctx *cli.Context) error {
-							cfg, err := LoadConfig(cctx.String("config"))
+							cfg, err := config.LoadConfig(cctx.String("config"))
 							if err != nil {
 								log.Fatal(err)
 							}
@@ -244,6 +275,13 @@ func main() {
 							if offerId == "" {
 								log.Printf("Please provide offerID to check deal status")
 								return nil
+							}
+
+							// Get chain name
+							chainName := cctx.String("chain")
+							srcCfg, err := config.GetSourceConfig(cfg, chainName)
+							if err != nil {
+								log.Fatalf("Invalid chain name '%s': %v", chainName, err)
 							}
 
 							//Request deal status from Lighthouse Deal Engine
@@ -262,13 +300,13 @@ func main() {
 							log.Println("proofSubtree is ", proofSubtree)
 
 							// Dial network
-							client, err := ethclient.Dial(cfg.Api)
+							client, err := ethclient.Dial(srcCfg.Api)
 							if err != nil {
 								log.Fatal(err)
 							}
 
 							// Load onramp contract handle
-							contractAddress := common.HexToAddress(cfg.OnRampAddress)
+							contractAddress := common.HexToAddress(srcCfg.OnRampAddress)
 							parsedABI, err := LoadAbi(cfg.OnRampABIPath)
 							if err != nil {
 								log.Fatal(err)
@@ -354,25 +392,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-type Config struct {
-	ChainID        int
-	Api            string
-	OnRampAddress  string
-	ProverAddr     string
-	KeyPath        string
-	ClientAddr     string
-	PayoutAddr     string
-	OnRampABIPath  string
-	BufferPath     string
-	BufferPort     int
-	TransferIP     string
-	TransferPort   int
-	ProviderAddr   string
-	LotusAPI       string
-	TargetAggSize  int
-	LighthouseAuth string
 }
 
 // Mirror OnRamp.sol's `Offer` struct
@@ -462,8 +481,8 @@ func NewLotusDaemonAPIClientV0(ctx context.Context, url string, timeoutSecs int,
 	return c, closer, nil
 }
 
-func NewAggregator(ctx context.Context, cfg *Config) (*aggregator, error) {
-	client, err := ethclient.Dial(cfg.Api)
+func NewAggregator(ctx context.Context, cfg *config.Config, srcCfg *config.SourceChainConfig) (*aggregator, error) {
+	client, err := ethclient.Dial(srcCfg.Api)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -472,8 +491,8 @@ func NewAggregator(ctx context.Context, cfg *Config) (*aggregator, error) {
 	if err != nil {
 		return nil, err
 	}
-	proverContractAddress := common.HexToAddress(cfg.ProverAddr)
-	onRampContractAddress := common.HexToAddress(cfg.OnRampAddress)
+	proverContractAddress := common.HexToAddress(cfg.Destination.ProverAddr)
+	onRampContractAddress := common.HexToAddress(srcCfg.OnRampAddress)
 	payoutAddress := common.HexToAddress(cfg.PayoutAddr)
 	onramp := bind.NewBoundContract(onRampContractAddress, *parsedABI, client, client, client)
 
@@ -487,7 +506,7 @@ func NewAggregator(ctx context.Context, cfg *Config) (*aggregator, error) {
 		return nil, err
 	}
 
-	lAPI, closer, err := NewLotusDaemonAPIClientV0(ctx, cfg.LotusAPI, 1, "")
+	lAPI, closer, err := NewLotusDaemonAPIClientV0(ctx, cfg.Destination.LotusAPI, 1, "")
 	if err != nil {
 		return nil, err
 	}
@@ -651,15 +670,15 @@ func (a *aggregator) sendingToLighthouseDe(ctx context.Context) error {
 }
 
 // Request Deal Status from Lighthouse Engine and send PoDSI to onramp contract
-func processDealStatus(ctx context.Context, cfg *Config, cid string) error {
+func processDealStatus(ctx context.Context, cfg *config.Config, cid string) error {
 	//Request deal status from Lighthouse Deal Engine
 	proofResponse, err := getDealStatus(cid, cfg.LighthouseAuth)
 	if err != nil {
 		log.Fatalf("Error in GET request: %v", err)
 	}
 	// Print or log the response body
-	log.Printf("PoDSI Proof: %s", proofResponse.Proof)
-	log.Printf("Filecoin Deal: %s", proofResponse.FilecoinDeals)
+	log.Printf("PoDSI Proof: %v", proofResponse.Proof)
+	log.Printf("Filecoin Deal: %v", proofResponse.FilecoinDeals)
 
 	// Log the end of the process
 	log.Println("Process completed successfully.")
@@ -1143,38 +1162,9 @@ func MakeOffer(commpStr string, sizeStr string, cidStr string, location string, 
 	return &offer, nil
 }
 
-// Load Config given path to JSON config file
-func LoadConfig(path string) (*Config, error) {
-	path, err := homedir.Expand(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get absolute path: %w", err)
-	}
-
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open config file: %w", err)
-	}
-	defer file.Close()
-
-	bs, err := io.ReadAll(file)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config bytes from file: %w", err)
-	}
-	var cfg []Config
-
-	err = json.Unmarshal(bs, &cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode config file: %v", err)
-	}
-	if len(cfg) != 1 {
-		return nil, fmt.Errorf("expected 1 config, got %d", len(cfg))
-	}
-	return &cfg[0], nil
-}
-
 // Load and unlock the keystore with XCHAIN_PASSPHRASE env var
 // return a transaction authorizer
-func loadPrivateKey(cfg *Config) (*bind.TransactOpts, error) {
+func loadPrivateKey(cfg *config.Config) (*bind.TransactOpts, error) {
 	path, err := homedir.Expand(cfg.KeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get absolute path: %w", err)
@@ -1206,7 +1196,7 @@ func loadPrivateKey(cfg *Config) (*bind.TransactOpts, error) {
 		return nil, fmt.Errorf("failed to unlock keystore: %w", err)
 	}
 
-	return bind.NewKeyStoreTransactorWithChainID(ks, a, big.NewInt(int64(cfg.ChainID)))
+	return bind.NewKeyStoreTransactorWithChainID(ks, a, big.NewInt(int64(cfg.Destination.ChainID)))
 }
 
 // Load contract abi at the given path

--- a/xchain.go
+++ b/xchain.go
@@ -159,10 +159,28 @@ func main() {
 			},
 			{
 				Name:  "client",
-				Usage: "Send data from cross chain to filecoin",
+				Usage: "Send car file from cross chain to filecoin",
 				Subcommands: []*cli.Command{
 					{
-						Name:      "offer",
+						Name:      "offer-file",
+						Usage:     "Offer data by providing a file and payment parameters (file is pre-processed automatically)",
+						ArgsUsage: "<file_path> <payment-addr> <payment-amount>",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:  "config",
+								Usage: "Path to the configuration file",
+								Value: "./config/config.json",
+							},
+							&cli.StringFlag{
+								Name:     "chain",
+								Usage:    "Name of the source blockchain (e.g., ethereum, polygon)",
+								Required: true,
+							},
+						},
+						Action: offerFileAction,
+					},
+					{
+						Name:      "offer-car",
 						Usage:     "Offer data by providing file and payment parameters",
 						ArgsUsage: "<commP> <size> <cid> <bufferLocation> <token-hex> <token-amount>",
 						Flags: []cli.Flag{

--- a/xchain_test.go
+++ b/xchain_test.go
@@ -33,7 +33,7 @@ func TestChainIdEncoding(t *testing.T) {
 	// Connect to the Ethereum client
 	client, err := ethclient.Dial(srcCfg.Api)
 	if err != nil {
-		t.Fatalf("failed to connect to the Ethereum client: %v", err)
+		t.Fatalf("failed to connect to the Ethereum client on %s: %v", srcCfg.Api, err)
 	}
 
 	// Query the chain ID

--- a/xchain_test.go
+++ b/xchain_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"math/big"
 	"testing"
 
+	"github.com/FIL-Builders/xchainClient/config"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
@@ -14,15 +16,22 @@ import (
 
 // Test function to test chainID encoding
 func TestChainIdEncoding(t *testing.T) {
-	configPath := "~/.xchain/config.json" // Replace with the actual path to your config file
+	configPath := "./config/config.json" // Replace with the actual path to your config file
 
-	config, err := LoadConfig(configPath); 
+	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
 		t.Fatalf("failed to unmarshal config: %v", err)
 	}
 
+	// Get source chain name
+	chainName := "avalanche"
+	srcCfg, err := config.GetSourceConfig(cfg, chainName)
+	if err != nil {
+		log.Fatalf("Invalid chain name '%s': %v", chainName, err)
+	}
+
 	// Connect to the Ethereum client
-	client, err := ethclient.Dial(config.Api)
+	client, err := ethclient.Dial(srcCfg.Api)
 	if err != nil {
 		t.Fatalf("failed to connect to the Ethereum client: %v", err)
 	}
@@ -30,7 +39,7 @@ func TestChainIdEncoding(t *testing.T) {
 	// Query the chain ID
 	chainID, err := client.ChainID(context.Background())
 	if err != nil {
-		t.Fatalf("failed to get chain ID: %v", err)
+		t.Fatalf("failed to query %s to get chain ID: %v", srcCfg.Api, err)
 	}
 
 	// Encode the chainID
@@ -42,7 +51,7 @@ func TestChainIdEncoding(t *testing.T) {
 	fmt.Println("Encoded chainID: ", encodedChainID)
 	fmt.Println("chainID: ", chainID)
 	hexEncodedChainID := hex.EncodeToString(encodedChainID)
-    fmt.Printf("Encoded ChainID in Hex: %s\n", hexEncodedChainID)
+	fmt.Printf("Encoded ChainID in Hex: %s\n", hexEncodedChainID)
 	decodedChainID, err := decodeChainID(encodedChainID)
 	if err != nil {
 		t.Fatalf("failed to decode chainID: %v", err)
@@ -52,31 +61,31 @@ func TestChainIdEncoding(t *testing.T) {
 }
 
 func decodeChainID(data []byte) (*big.Int, error) {
-    // Define the ABI arguments
-    uint256Type, err := abi.NewType("uint256", "", nil)
-    if err != nil {
-        return nil, fmt.Errorf("failed to create uint256 type: %w", err)
-    }
+	// Define the ABI arguments
+	uint256Type, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create uint256 type: %w", err)
+	}
 
-    arguments := abi.Arguments{
-        {Type: uint256Type}, // chainID is a uint256 in Solidity
-    }
+	arguments := abi.Arguments{
+		{Type: uint256Type}, // chainID is a uint256 in Solidity
+	}
 
-    // Unpack the byte array into a slice of interface{}
-    unpacked, err := arguments.Unpack(data)
-    if err != nil {
-        return nil, fmt.Errorf("failed to decode chainID: %w", err)
-    }
+	// Unpack the byte array into a slice of interface{}
+	unpacked, err := arguments.Unpack(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode chainID: %w", err)
+	}
 
-    // Extract the chainID from the unpacked slice
-    if len(unpacked) == 0 {
-        return nil, fmt.Errorf("no data unpacked")
-    }
+	// Extract the chainID from the unpacked slice
+	if len(unpacked) == 0 {
+		return nil, fmt.Errorf("no data unpacked")
+	}
 
-    chainID, ok := unpacked[0].(*big.Int)
-    if !ok {
-        return nil, fmt.Errorf("failed to assert type to *big.Int")
-    }
+	chainID, ok := unpacked[0].(*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type to *big.Int")
+	}
 
-    return chainID, nil
+	return chainID, nil
 }

--- a/xchain_test.go
+++ b/xchain_test.go
@@ -33,13 +33,13 @@ func TestChainIdEncoding(t *testing.T) {
 	// Connect to the Ethereum client
 	client, err := ethclient.Dial(srcCfg.Api)
 	if err != nil {
-		t.Fatalf("failed to connect to the Ethereum client on %s: %v", srcCfg.Api, err)
+		t.Fatalf("failed to connect to Ethereum client for source chain %s at %s: %v", chainName, srcCfg.Api, err)
 	}
 
 	// Query the chain ID
 	chainID, err := client.ChainID(context.Background())
 	if err != nil {
-		t.Fatalf("failed to query %s to get chain ID: %v", srcCfg.Api, err)
+		t.Fatalf("failed to query source chain %s at %s to get chain ID: %v", chainName, srcCfg.Api, err)
 	}
 
 	// Encode the chainID


### PR DESCRIPTION
### Changes Introduced:
- Added `client.go` to handle CAR file creation, CommP computation, and blockchain offer submission.
- Implemented `offer-file` CLI command, which automates the file preprocessing and submission process.
- Updated `xchain.go` to integrate the `offer-file` command alongside existing `offer-car` functionality.
- Improved CLI flexibility by introducing configuration flags for specifying the blockchain source.

### Why This Change?
This feature streamlines the offering process by automating the required file conversions and CommP calculations, reducing the need for manual intervention.

### How to Test:
1. Build the project using `go build -o xchainClient`.
2. Run `./xchainClient client offer-file <file_path> <payment-addr> <payment-amount> --chain ethereum --config ./config/config.json`.
3. Verify the transaction details and on-chain submission logs.

### Related Issues:
Closes #6 
